### PR TITLE
When printing, show SVGs as solid black.

### DIFF
--- a/src/icons/icons.scss
+++ b/src/icons/icons.scss
@@ -1,9 +1,13 @@
-// @media print {
-    .LogotypeIcon path {
-        width: auto;
-        height: auto;
+@media print {
+    path {
+        fill: black !important;
     }
-// }
+}
+
+.LogotypeIcon path {
+    width: auto;
+    height: auto;
+}
 
 .ColoredIcon {
     &.icon-fg-color path {


### PR DESCRIPTION
e.g. the primary logo includes white text for ‘izzy’
which doesn’t show up when printing.
