### PR TITLE
Service provisions redesign

### DIFF
--- a/script/test
+++ b/script/test
@@ -15,4 +15,10 @@ fi
 # build assets if this isn't Travis (which has already)
 ${CI:=false} || ./script/build-assets
 
-mocha --timeout 0 --compilers js:babel/register test/*.js "$@"
+if [ -z "$@" ]; then
+    TESTS=test/*.js
+else
+    TESTS="$@"
+fi
+
+mocha --timeout 0 --compilers js:babel/register "$TESTS"

--- a/script/test
+++ b/script/test
@@ -15,10 +15,4 @@ fi
 # build assets if this isn't Travis (which has already)
 ${CI:=false} || ./script/build-assets
 
-if [ -z "$@" ]; then
-    TESTS=test/*.js
-else
-    TESTS="$@"
-fi
-
-mocha --timeout 0 --compilers js:babel/register "$TESTS"
+mocha --timeout 0 --compilers js:babel/register $@

--- a/src/ServiceProvisions.js
+++ b/src/ServiceProvisions.js
@@ -1,0 +1,168 @@
+/* @flow */
+
+"use strict";
+
+import _ from 'underscore';
+
+function escapeRegex(s) {
+    return s.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
+};
+
+/**
+ * ServiceProvision aka provides:
+ *
+ * A single service provision, which has a display name and a representation
+ * to match.
+ *
+ * The representation can be a form object, string or regular expression.
+ * See anyOf, allOf, not and keywords.
+ */
+export class ServiceProvision {
+    /* The display name */
+    name: string;
+    /* Form to match */
+    form: Form;
+
+    constructor(props: {
+        name: string,
+        form: Form|string|RegExp;
+    }) {
+        this.name = props.name;
+
+        if (props.form instanceof Form) {
+            this.form = props.form;
+        } else {
+            this.form = anyOf(props.form);
+        }
+    }
+
+    match(input: string): boolean {
+        return this.form.match(input);
+    }
+}
+
+export function provides(props: {
+    name: string,
+    form: Form|string|RegExp,
+}): ServiceProvision {
+    return new ServiceProvision(props);
+}
+
+class Form {
+    match(input: string): boolean {
+        return true;
+    }
+}
+
+class RegexpForm extends Form {
+    form: RegExp;
+
+    constructor(re: RegExp|string) {
+        super();
+        this.form = new RegExp(re, 'i');
+    }
+
+    match(input) {
+        return this.form.test(input);
+    }
+}
+
+class ListForm extends Form {
+    forms: Array<Form>;
+
+    constructor(...forms: Array<Form|string|RegExp>) {
+        super();
+        this.forms = forms.map(form => {
+            if (form instanceof Form) {
+                return form;
+            } else if (form instanceof RegExp) {
+                return new RegexpForm(form);
+            } else {
+                return keywords(form);
+            }
+        });
+    }
+}
+
+class AnyOf extends ListForm {
+    match(input) {
+        return _.some(this.forms, form => form.match(input));
+    }
+}
+
+export function anyOf(...forms: Array<Form|string|RegExp>): AnyOf {
+    return new AnyOf(...forms);
+}
+
+class AllOf extends ListForm {
+    match(input) {
+        return _.every(this.forms, form => form.match(input));
+    }
+}
+
+export function allOf(...forms: Array<Form|string|RegExp>): AllOf {
+    return new AllOf(...forms);
+}
+
+class Not extends AnyOf {
+    match(input) {
+        return !super.match(input);
+    }
+}
+
+export function not(...forms: Array<Form|string|RegExp>): Not {
+    return new Not(...forms);
+}
+
+class Keywords extends RegexpForm {
+    form: RegExp;
+
+    constructor(...forms: Array<string|RegExp>) {
+
+        /* a regular expression matching things that appear on word
+         * boundaries
+         * FIXME: requires consecutive keywords to have 2 spaces between
+         */
+        var wordTerminator = /(?:^|$|[\s,;"])/
+            .source;
+
+        /* a regular expression of all the keywords, surrounded by word
+         * terminators. And in the order given. */
+        var form = forms
+            .map(form => {
+                if (form instanceof RegExp) {
+                    var form = form.source
+                        /* normalise space */
+                        .replace(/\s+/g, '\\s+');
+
+                    /* wrap the regex in a group to avoid regex leaking out */
+                    form = `(?:${form})`;
+                } else {
+                    form = escapeRegex(form)
+                        /* normalise strings to the hyphen or non-hyphen
+                         * version */
+                        .replace(/\\-/g, '[- ]')
+                        /* normalise space */
+                        .replace(/\s+/g, '\\s+');
+                }
+
+                return `${wordTerminator}${form}${wordTerminator}`;
+            }
+        )
+            .join('[^.]*');
+
+        super(form);
+    }
+
+    match(input) {
+        /* FIXME: This is a hack to handle the fact that word tokenizing regex
+         * needs two spaces between consecutive terms */
+        input = input.replace(/\s+/g, '  ');
+
+        return super.match(input);
+    }
+}
+
+export function keywords(...args: Array<string|RegExp>): Keywords {
+    return new Keywords(...args);
+}

--- a/src/ServiceProvisions.js
+++ b/src/ServiceProvisions.js
@@ -155,9 +155,14 @@ class Keywords extends RegexpForm {
     }
 
     match(input) {
-        /* FIXME: This is a hack to handle the fact that word tokenizing regex
-         * needs two spaces between consecutive terms */
-        input = input.replace(/\s+/g, '  ');
+        input = input
+            /* FIXME: This is a hack to handle the fact that word tokenizing
+             * regex needs two spaces between consecutive terms */
+            .replace(/\s+/g, '  ')
+            /* And that a keyword at the send of a sentence needs a word
+             * breaker before the fullstop -- we don't add full-stop as a word
+             * break because it's already a sentence break */
+            .replace(/\./g, ' . ');
 
         return super.match(input);
     }

--- a/src/components/ResultListItem.js
+++ b/src/components/ResultListItem.js
@@ -17,13 +17,6 @@ var palette = colors.getPalette();
 
 /*::`*/@reactMixin.decorate(Router.Navigation)/*::`;*/
 class ResultListItem extends React.Component {
-    constructor(props: Object) {
-        super(props);
-        this.state = {
-            relatedServices: [],  // includes us, use this.relatedServices
-        };
-    }
-
     // flow:disable not supported yet
     static propTypes = {
         object: React.PropTypes.instanceOf(iss.Service).isRequired,
@@ -39,23 +32,13 @@ class ResultListItem extends React.Component {
     };
 
     /**
-     * relatedServices:
-     * A list of related services, limited to 4
-     */
-    /* flow:disable */
-    get relatedServices(): Array<Object> {
-        return this.state.relatedServices
-            .slice(0, this.props.nServiceProvisions);
-    }
-
-    /**
      * nMoreServiceProvisions:
      * The number of related services minus the 4 relatedServices.
      */
     /* flow:disable */
     get nMoreServiceProvisions(): number {
         return Math.max(0,
-                        this.state.relatedServices.length -
+                        this.props.object.serviceProvisions.length -
                             this.props.nServiceProvisions);
     }
 
@@ -87,18 +70,25 @@ class ResultListItem extends React.Component {
                 <TransportTime object={object} />
                 { this.props.nServiceProvisions > 0 ?
                     <div>
-                    <ul className="related">{
-                        object.serviceProvisions.map((service, index) =>
-                            <li key={index}>{service}</li>
-                        )
-                    }</ul>
-                    {this.nMoreServiceProvisions > 0 ?
-                        <div>
-                            {this.nMoreServiceProvisions} more…
-                        </div>
-                    :
-                        ''
-                    }</div>
+                        <ul className="related">{
+                            object.serviceProvisions
+                                .slice(0, this.props.nServiceProvisions)
+                                .map((service, index) =>
+                                    <li className="provision"
+                                        key={index}
+                                    >
+                                        {service}
+                                    </li>
+                                )
+                        }</ul>
+                        { this.nMoreServiceProvisions > 0 ?
+                            <div>
+                                {this.nMoreServiceProvisions} more…
+                            </div>
+                        :
+                            ''
+                        }
+                    </div>
                 :
                     ''
                 }

--- a/src/constants/service-provisions.js
+++ b/src/constants/service-provisions.js
@@ -8,68 +8,183 @@
 
 "use strict";
 
-type ServiceProvision = {
-    /* canonical name for the service provision
-     * (this is the one we display) */
-    cname: string;
-    /* a description of what this service provision is */
-    description?: string;
-    /* other forms for this service provision
-     * (implicitly includes the cname) */
-    forms?: Array<RegExp|string>
-};
+import {
+    ServiceProvision,
+    allOf,
+    anyOf,
+    keywords,
+    not,
+    provides,
+} from '../ServiceProvisions';
 
-/* Please keep this sorted */
+/* Please keep this grouped */
 var serviceProvisions: Array<ServiceProvision> = [
-    {
-        cname: "Advice on legal matters",
-        forms: [
-            "legal advice",
-        ],
-    }, {
-        cname: "Civil law advice",
-        forms: [
-            /civil (law|matters)/,
-        ],
-    }, {
-        cname: "Criminal law advice",
-        forms: [
-            /criminal (law|matters)/,
-        ],
-    }, {
-        cname: "Crisis accommodation",
-        forms: [
-            /(crisis|emergency) (accommodation|housing|shelter)/,
-            "housing crisis",
-            "refuge accommodation",  // N.B. not refugee
-        ],
-    }, {
-        cname: "Family law advice",
-        forms: [
-            /family (law|matters)/,
-        ],
-    }, {
-        cname: "Legal assistance to help you pay for a lawyer",
-        forms: [
-            "legal aid",
-            "legal representation",
-        ],
-    }, {
-        cname: "Long-term accommodation",
-        forms: [
-            /long[ -]term (housing|accommodation)/,
-        ],
-    }, {
-        cname: "Short-term accommodation",
-        forms: [
-            /short[ -]term (housing|accommodation)/,
-        ],
-    }, {
-        cname: "Transitional accommodation",
-        forms: [
-            'transitional housing',
-        ],
-    },
+    /* General */
+    provides({
+        name: "Advice",
+        form: allOf(
+            'advice',
+            not('legal'),
+        ),
+    }),
+
+    /* Legal advice */
+    provides({
+        name: "Advice on legal matters",
+        form: "legal advice",
+    }),
+    provides({
+        name: "Civil law advice",
+        form: keywords('civil', /law|matters/),
+    }),
+    provides({
+        name: "Criminal law advice",
+        form: keywords('criminal', /law|matters/),
+    }),
+    provides({
+        name: "Family law advice",
+        form: keywords('family', /law|matters/),
+    }),
+
+    /* Food */
+    provides({
+        name: "Breakfast",
+        form: keywords('free', 'breakfast'),
+    }),
+    provides({
+        name: "Lunch",
+        form: keywords('free', 'lunch'),
+    }),
+    provides({
+        name: "Dinner",
+        form: keywords('free', /dinner|evening meal/),
+    }),
+
+    /* Accommodation */
+    provides({
+        name: "Family accommodation",
+        form: keywords('accommodation', 'for', 'families'),
+    }),
+    provides({
+        name: "Crisis accommodation",
+        form: anyOf(
+            keywords(/crisis|emergency/, /accommodation|housing|shelter/),
+            keywords('housing', 'crisis'),
+            keywords('refuge', 'accommodation'),  // N.B. not refugee
+        ),
+    }),
+
+    /* Case management */
+    provides({
+        name: "Case management",
+        form: allOf(
+            'case-management',
+            not(
+                'long-term',
+                'short-term',
+                'medium-term',
+            ),
+        ),
+    }),
+    provides({
+        name: "Short-term case management",
+        form: keywords('short', 'term', 'case management'),
+    }),
+    provides({
+        name: "Medium-term case management",
+        form: keywords('medium', 'term', 'case management'),
+    }),
+    provides({
+        name: "Long-term case management",
+        form: keywords('long', 'term', 'case management'),
+    }),
+
+    /* Material aid */
+    provides({
+        name: "Clothing",
+        form: 'clothing',
+    }),
+
+    /* Referrals */
+    provides({
+        name: "Drug & alcohol referrals",
+        form: keywords(/referrals?/, 'for', /drugs?/, 'alcohol'),
+    }),
+    provides({
+        name: "Referrals for financial counselling",
+        form: anyOf(
+            keywords(/referrals?/, 'for', 'financial', 'counselling'),
+            keywords(/referrals?/, 'to', 'financial', 'counsellors'),
+        ),
+    }),
+
+    // }, {
+        // cname: "Food parcels",
+        // forms: [
+            // "food (?!vouchers)",
+            // "food hampers",
+            // "food parcels",
+        // ],
+    // }, {
+        // ],
+    // }, {
+        // cname: "Housing information",
+        // forms: [
+            // /housing([^.]*) information/,
+            // /information([^.]*) housing/,
+        // ],
+    // }, {
+        // cname: "Housing referrals",
+        // forms: [
+            // /housing([^.]*) referrals?/,
+            // /referrals?([^.]*) housing/,
+        // ],
+    // }, {
+        // cname: "Legal assistance to help you pay for a lawyer",
+        // forms: [
+            // "legal aid",
+            // "legal representation",
+        // ],
+    // }, {
+        // cname: "Referrals for legal services",
+        // forms: [
+            // /referrals? for([^.]*) legal services/,
+        // ],
+    // }, {
+        // cname: "Long-term accommodation",
+        // forms: [
+            // /long[ -]term(.* and [^.]+)? (housing|accommodation)/,
+        // ],
+    // }, {
+        // cname: "Mental health referrals",
+        // forms: [
+            // /referrals? for([^.]*) mental health/,
+        // ],
+    // }, {
+        // cname: "Public transport cards",
+        // forms: [
+            // "Met cards",
+            // "Myki cards",
+        // ],
+    // }, {
+        // cname: "Short-term accommodation",
+        // forms: [
+            // /short[ -]term(.* and [^.]+)? (housing|accommodation)/,
+        // ],
+    // }, {
+        // cname: "Tenancy information",
+        // forms: [
+            // /tenancy([^.]*) information/,
+            // /information([^.]*) tenancy/,
+        // ],
+    // }, {
+        // cname: "Toiletries",
+    // }, {
+        // cname: "Transitional accommodation",
+        // forms: [
+            // /transitional(.* and [^.]+)? (housing|accommodation)/,
+        // ],
+    // },
 ];
 
 export default serviceProvisions;

--- a/src/constants/service-provisions.js
+++ b/src/constants/service-provisions.js
@@ -21,6 +21,11 @@ import {
 var serviceProvisions: Array<ServiceProvision> = [
     /* Accommodation */
     provides({
+        name: "Crisis accommodation for women fleeing domestic violence",
+        form: keywords(/crisis|emergency|refuge/, 'accommodation',
+                       'women', /family|domestic/, 'violence'),
+    }),
+    provides({
         name: "Family accommodation",
         form: keywords('accommodation', 'for', 'families'),
     }),
@@ -43,6 +48,17 @@ var serviceProvisions: Array<ServiceProvision> = [
     provides({
         name: "Transitional accommodation",
         form: keywords('transitional', /housing|accommodation/),
+    }),
+    provides({
+        name: "Public housing",
+        form: keywords("public", /housing|accommodation/),
+    }),
+    provides({
+        name: "Community housing",
+        form: allOf(
+            keywords(/community|social/, 'housing'),
+            not(/community|social/, 'housing tenants'),
+        ),
     }),
 
     /* Case management */

--- a/src/constants/service-provisions.js
+++ b/src/constants/service-provisions.js
@@ -17,49 +17,8 @@ import {
     provides,
 } from '../ServiceProvisions';
 
-/* Please keep this grouped */
+/* Please keep this grouped and the groups sorted */
 var serviceProvisions: Array<ServiceProvision> = [
-    /* General */
-    provides({
-        name: "Advice",
-        form: allOf(
-            'advice',
-            not('legal'),
-        ),
-    }),
-
-    /* Legal advice */
-    provides({
-        name: "Advice on legal matters",
-        form: "legal advice",
-    }),
-    provides({
-        name: "Civil law advice",
-        form: keywords('civil', /law|matters/),
-    }),
-    provides({
-        name: "Criminal law advice",
-        form: keywords('criminal', /law|matters/),
-    }),
-    provides({
-        name: "Family law advice",
-        form: keywords('family', /law|matters/),
-    }),
-
-    /* Food */
-    provides({
-        name: "Breakfast",
-        form: keywords('free', 'breakfast'),
-    }),
-    provides({
-        name: "Lunch",
-        form: keywords('free', 'lunch'),
-    }),
-    provides({
-        name: "Dinner",
-        form: keywords('free', /dinner|evening meal/),
-    }),
-
     /* Accommodation */
     provides({
         name: "Family accommodation",
@@ -72,6 +31,18 @@ var serviceProvisions: Array<ServiceProvision> = [
             keywords('housing', 'crisis'),
             keywords('refuge', 'accommodation'),  // N.B. not refugee
         ),
+    }),
+    provides({
+        name: "Short-term accommodation",
+        form: keywords('short-term', /housing|accommodation/),
+    }),
+    provides({
+        name: "Long-term accommodation",
+        form: keywords('long-term', /housing|accommodation/),
+    }),
+    provides({
+        name: "Transitional accommodation",
+        form: keywords('transitional', /housing|accommodation/),
     }),
 
     /* Case management */
@@ -99,10 +70,92 @@ var serviceProvisions: Array<ServiceProvision> = [
         form: keywords('long', 'term', 'case management'),
     }),
 
+    /* Food */
+    provides({
+        name: "Breakfast",
+        form: keywords('free', 'breakfast'),
+    }),
+    provides({
+        name: "Lunch",
+        form: keywords('free', 'lunch'),
+    }),
+    provides({
+        name: "Dinner",
+        form: keywords('free', /dinner|evening meal/),
+    }),
+
+    /* General */
+    provides({
+        name: "Advice",
+        form: allOf(
+            'advice',
+            not('legal'),
+        ),
+    }),
+    provides({
+        name: "Support services",
+        form: 'support services',
+    }),
+
+    /* Information */
+    provides({
+        name: "Housing information",
+        form: anyOf(
+            keywords('housing', 'information'),
+            keywords('information', 'housing'),
+        ),
+    }),
+    provides({
+        name: "Tenancy information",
+        form: anyOf(
+            keywords('tenancy', 'information'),
+            keywords('information', 'tenancy'),
+        ),
+    }),
+
+    /* Legal advice */
+    provides({
+        name: "Advice on legal matters",
+        form: "legal advice",
+    }),
+    provides({
+        name: "Civil law advice",
+        form: keywords('civil', /law|matters/),
+    }),
+    provides({
+        name: "Criminal law advice",
+        form: keywords('criminal', /law|matters/),
+    }),
+    provides({
+        name: "Family law advice",
+        form: keywords('family', /law|matters/),
+    }),
+
+    /* Legal aid */
+    provides({
+        name: "Legal assistance to help you pay for a lawyer",
+        form: anyOf(
+            "legal aid",
+            "legal representation",
+        ),
+    }),
+
     /* Material aid */
     provides({
         name: "Clothing",
         form: 'clothing',
+    }),
+    provides({
+        name: "Food parcels",
+        form: keywords('food', /hampers|parcels/),
+    }),
+    provides({
+        name: "Public transport cards",
+        form: keywords(/met|myki|public transport/, 'cards'),
+    }),
+    provides({
+        name: "Toiletries",
+        form: 'toiletries',
     }),
 
     /* Referrals */
@@ -112,79 +165,23 @@ var serviceProvisions: Array<ServiceProvision> = [
     }),
     provides({
         name: "Referrals for financial counselling",
+        form: keywords(/referrals?/, /for|to/, 'financial', /counsell\w+/),
+    }),
+    provides({
+        name: "Referrals for legal services",
+        form: keywords(/referrals?/, 'for', 'legal services'),
+    }),
+    provides({
+        name: "Housing referrals",
         form: anyOf(
-            keywords(/referrals?/, 'for', 'financial', 'counselling'),
-            keywords(/referrals?/, 'to', 'financial', 'counsellors'),
+            keywords('housing', /referrals?/),
+            keywords(/referrals?/, 'for', 'housing'),
         ),
     }),
-
-    // }, {
-        // cname: "Food parcels",
-        // forms: [
-            // "food (?!vouchers)",
-            // "food hampers",
-            // "food parcels",
-        // ],
-    // }, {
-        // ],
-    // }, {
-        // cname: "Housing information",
-        // forms: [
-            // /housing([^.]*) information/,
-            // /information([^.]*) housing/,
-        // ],
-    // }, {
-        // cname: "Housing referrals",
-        // forms: [
-            // /housing([^.]*) referrals?/,
-            // /referrals?([^.]*) housing/,
-        // ],
-    // }, {
-        // cname: "Legal assistance to help you pay for a lawyer",
-        // forms: [
-            // "legal aid",
-            // "legal representation",
-        // ],
-    // }, {
-        // cname: "Referrals for legal services",
-        // forms: [
-            // /referrals? for([^.]*) legal services/,
-        // ],
-    // }, {
-        // cname: "Long-term accommodation",
-        // forms: [
-            // /long[ -]term(.* and [^.]+)? (housing|accommodation)/,
-        // ],
-    // }, {
-        // cname: "Mental health referrals",
-        // forms: [
-            // /referrals? for([^.]*) mental health/,
-        // ],
-    // }, {
-        // cname: "Public transport cards",
-        // forms: [
-            // "Met cards",
-            // "Myki cards",
-        // ],
-    // }, {
-        // cname: "Short-term accommodation",
-        // forms: [
-            // /short[ -]term(.* and [^.]+)? (housing|accommodation)/,
-        // ],
-    // }, {
-        // cname: "Tenancy information",
-        // forms: [
-            // /tenancy([^.]*) information/,
-            // /information([^.]*) tenancy/,
-        // ],
-    // }, {
-        // cname: "Toiletries",
-    // }, {
-        // cname: "Transitional accommodation",
-        // forms: [
-            // /transitional(.* and [^.]+)? (housing|accommodation)/,
-        // ],
-    // },
+    provides({
+        name: "Mental health referrals",
+        form: keywords(/referrals?/, 'for', 'mental health'),
+    }),
 ];
 
 export default serviceProvisions;

--- a/src/iss.js
+++ b/src/iss.js
@@ -157,20 +157,13 @@ export class Service {
         }
 
         try {
-            this._serviceProvisions = [];
-
-            for (var provision of serviceProvisions) {
-                var forms = provision.forms || [provision.cname];
-                var anti_forms = provision.anti_forms || [];
-
-                if (_.some(forms.map(form => new RegExp(form, 'i')),
-                           form => this.description.match(form)) &&
-                   !_.some(anti_forms.map(form => new RegExp(form, 'i')),
-                           form => this.description.match(form))
-                ) {
-                    this._serviceProvisions.push(provision.cname);
-                }
-            }
+            this._serviceProvisions = [
+                /*::`*/
+                for (provision of serviceProvisions)
+                if (provision.match(this.description))
+                provision.name
+                /*::`*/
+            ];
         } catch (e) {
             console.error("Failed to determine service provisions", e);
         }

--- a/src/iss.js
+++ b/src/iss.js
@@ -160,10 +160,14 @@ export class Service {
             this._serviceProvisions = [];
 
             for (var provision of serviceProvisions) {
-                var forms = [provision.cname].concat(provision.forms || []);
+                var forms = provision.forms || [provision.cname];
+                var anti_forms = provision.anti_forms || [];
 
                 if (_.some(forms.map(form => new RegExp(form, 'i')),
-                           form => this.description.match(form))) {
+                           form => this.description.match(form)) &&
+                   !_.some(anti_forms.map(form => new RegExp(form, 'i')),
+                           form => this.description.match(form))
+                ) {
                     this._serviceProvisions.push(provision.cname);
                 }
             }

--- a/test/features/10-functional/10-basic/20-category-page.feature
+++ b/test/features/10-functional/10-basic/20-category-page.feature
@@ -43,17 +43,21 @@ Feature: Category page
         Then I should see "Emergency Accom"
         And I should be at /category/housing
 
-    # FIXME: This test is no longer relevant because we show service provisions
-    # not related services.
-    #
-    # Scenario: A service with 5 related services only shows 4
-        # When I visit /category/food
+    Scenario: A service with 5 related services only shows 4
+        When I visit /category/food
 
-        # Then I should see "Material Aid"
-        # And I should see "Community Outreach"
-        # And I should see "Crisis Accommodation"
-        # And I should see "Centrelink Services"
-        # And I should not see "Drug & Alcohol Counselling"
+        Then I should see the results
+        ------------------------------
+        Service Provisions (provision)
+        ==============================
+        Lunch
+        Advice
+        Support services
+        Housing referrals
+        ------------------------------
+
+        And I should not see "Mental health referrals"
+        And I should see "1 more…"
 
     Scenario: I should never see "invalid date"
         When I visit /category/housing

--- a/test/service-provisions.js
+++ b/test/service-provisions.js
@@ -1,0 +1,33 @@
+/**
+ * Test service provisions
+ */
+
+/* @flow */
+
+"use strict";
+
+import assert from 'assert';
+import fs from 'fs';
+import yaml from 'js-yaml';
+
+import serviceProvisions from '../src/constants/service-provisions';
+
+// import the test cases
+var tests = yaml.safeLoad(
+    fs.readFileSync('./test/service-provisions.yaml', 'utf8')
+);
+
+describe("Service Provisions", function() {
+    tests.tests.forEach(
+        test => it(test.description, () => {
+            var provides = [
+                /*::`*/
+                for (provision of serviceProvisions)
+                if (provision.match(test.description))
+                provision.name
+                /*::`*/
+            ];
+
+            assert.deepEqual(provides, test.provides);
+        }));
+});

--- a/test/service-provisions.yaml
+++ b/test/service-provisions.yaml
@@ -1,4 +1,15 @@
 tests:
+    # This example is used in functional tests.
+    - description: |
+        A weekly free lunch for those in need.  Referrals for mental health and
+        housing are also available as is advice and a range of support services.
+      provides:
+          - Lunch
+          - Advice
+          - Support services
+          - Housing referrals
+          - Mental health referrals
+
     - description: |
         Short to medium term case management support and advocacy for social
         housing tenants and housing applicants most in need.

--- a/test/service-provisions.yaml
+++ b/test/service-provisions.yaml
@@ -1,0 +1,33 @@
+tests:
+    - description: |
+        Short to medium term case management support and advocacy for social
+        housing tenants and housing applicants most in need.
+      provides:
+          - Short-term case management
+          - Medium-term case management
+
+    - description: |
+        Provides comprehensive and ongoing support and advocacy for social
+        housing tenants and housing applicants most in need. Case-management
+        services available to help social housing tenants maintain their
+        tenancies include development of plans for repayment of rent arrears &
+        referral to financial counsellors where required; referral to
+        specialist services for problems relating to family breakdown or mental
+        health; disability support; and assistance to overcome literacy &
+        language difficulties that may present barriers to communication with
+        the Office of Housing. Advocacy services for social housing tenants
+        focus on complex housing problems and may deal with issues such as
+        neighbourhood disputes, complaints about the Office of Housing, housing
+        appeals and Victorian Civil & Administrative Tribunal (VCAT) hearings.
+        Referral services are provided for those with less complex needs.
+      provides:
+          - Case management
+          - Referrals for financial counselling
+
+    - description: |
+        Provides accommodation and support services for families experiencing
+        homelessness, with a focus on those families living in rooming house
+        accommodation.
+      provides:
+          - Family accommodation
+          - Support services

--- a/test/service-provisions.yaml
+++ b/test/service-provisions.yaml
@@ -23,6 +23,8 @@ tests:
       provides:
           - Case management
           - Referrals for financial counselling
+          - Housing referrals
+          - Mental health referrals
 
     - description: |
         Provides accommodation and support services for families experiencing

--- a/test/service-provisions.yaml
+++ b/test/service-provisions.yaml
@@ -44,3 +44,12 @@ tests:
       provides:
           - Family accommodation
           - Support services
+
+    - description: |
+        Provides short-term crisis accommodation for Aboriginal women and
+        children who are survivors of family violence. Non-indigenous women
+        with children of Aboriginal partners are accepted.
+      provides:
+          - Crisis accommodation for women fleeing domestic violence
+          - Crisis accommodation
+          - Short-term accommodation

--- a/test/support/mock_iss/server.js
+++ b/test/support/mock_iss/server.js
@@ -71,7 +71,11 @@ app.get('/api/v3/search/', (req, res) => {
                 {
                     id: 444,
                     name: "Community Lunch",
-                    description: "A weekly lunch.",
+                    description:
+                        "A weekly free lunch for those in need. " +
+                        "Referrals for mental health and housing are also " +
+                        "available as is advice and a range of support " +
+                        "services.",
                     site: {
                         id: 444,
                         name: "Youth Support Net",


### PR DESCRIPTION
This is a complete redesign of the service provisions work to make it much more descriptive.
- Allow finding keywords within sentences without writing complicated regexes.
- Introduce common regexes for optional hyphens and space normalisation.
- Yaml file of test cases that are fed into Mocha as unit tests.
- anyOf, allOf, not, and keywords allow for descriptive matching of provisions.
- Much more OO, so easy to write even more complicated rules if we need to.
