### PR TITLE
Fix styling bug on crisis lines in prod

### DIFF
--- a/src/pages/ResultsListPage.js
+++ b/src/pages/ResultsListPage.js
@@ -114,7 +114,7 @@ class ResultsListPage extends BaseResultsPage {
                         object={object}
                       />;
 
-                    var klass = elem.type.name || "other";
+                    var klass = elem.displayName || "other";
 
                     return (
                         <div


### PR DESCRIPTION
This occurred when CSS was minified (as in prod). Can be reproduced by running prod-server. 

elem.displayName is safer than elem.type.name for this purpose!

Fixes https://trello.com/c/GhHSiFCS/194-grey-line-appears-between-crisis-lines-on-ios-and-windows-mobile
