### PR TITLE
Split large vendored libraries out

### DIFF
--- a/webpack/dev.config.js
+++ b/webpack/dev.config.js
@@ -8,6 +8,7 @@ import path        from "path";
 import webpack     from "webpack";
 import writeStats  from "./utils/write-stats";
 import notifyStats from "./utils/notify-stats";
+import commons     from "./utils/commons";
 import env         from "./env";
 import progress    from "./utils/progress";
 import extractText from "./extract-text";
@@ -25,6 +26,7 @@ module.exports = {
             "./src/client-entry.js",
             "./src/styles/bundle.scss",
         ],
+        vendor: ["react", "material-ui", "core-decorators", "material-ui", "moment", "react-google-maps", "react-router", "react-tap-event-plugin", "react", "underscore.string", "underscore"],
     },
     output: {
         path: assetsPath,
@@ -62,6 +64,8 @@ module.exports = {
         }),
 
         extractText.plugin,
+
+        commons,
 
         // stats
         function() {

--- a/webpack/prod.config.js
+++ b/webpack/prod.config.js
@@ -5,6 +5,7 @@
 import path              from "path";
 import webpack           from "webpack";
 import writeStats        from "./utils/write-stats";
+import commons           from "./utils/commons";
 import env               from "./env";
 import extractText       from "./extract-text";
 
@@ -17,6 +18,7 @@ module.exports = {
             "./src/client-entry.js",
             "./src/styles/bundle.scss",
         ],
+        vendor: ["react", "material-ui", "core-decorators", "material-ui", "moment", "react-google-maps", "react-router", "react-tap-event-plugin", "react", "underscore.string", "underscore"],
     },
     output: {
         path: assetsPath,
@@ -66,9 +68,11 @@ module.exports = {
                 warnings: false,
             },
         }),
+        commons,
 
         // stats
         function() { this.plugin("done", writeStats); },
 
     ],
 };
+

--- a/webpack/utils/commons.js
+++ b/webpack/utils/commons.js
@@ -1,0 +1,12 @@
+import webpack from "webpack";
+
+module.exports = new webpack.optimize.CommonsChunkPlugin({
+  name: "runtime",
+
+  filename: "webpack-runtime-[hash].js",
+  // (Give the chunk a different name)
+
+  minChunks: Infinity,
+  // (with more entries, this ensures that no other module
+  //  goes into the vendor chunk)
+});


### PR DESCRIPTION
This puts react (600kb) and material-ui (500kb) into their own bundle (along with a few of the other larger libraries).
