### PR TITLE
Add transport time/directions link to service detail view

### DIFF
--- a/src/components/Address.js
+++ b/src/components/Address.js
@@ -6,6 +6,17 @@ import { titleize } from "underscore.string";
 import ScreenReader from "./ScreenReader";
 
 class Address extends React.Component {
+    // flow:disable not supported yet
+    static propTypes = {
+        street_number: React.PropTypes.String,
+        street_name: React.PropTypes.String,
+        street_type: React.PropTypes.String,
+        street_suffix: React.PropTypes.String,
+        suburb: React.PropTypes.String,
+        state: React.PropTypes.String,
+        postcode: React.PropTypes.String,
+        isConfidential: React.PropTypes.Boolean,
+    };
 
     // flow:disable not supported yet
     static sampleProps = {default: fixtures.ixa.location};
@@ -23,6 +34,35 @@ class Address extends React.Component {
     }
 
     render(): ReactElement {
+
+        var suburb = [
+            titleize(this.props.suburb),
+            this.props.state,
+            titleize(this.props.postcode),
+        ].join(" ").trim();
+
+        if (this.props.isConfidential) {
+            return (
+                    <div className="Address">
+                        <ScreenReader>
+                            <h4>Address</h4>
+                        </ScreenReader>
+                        <div className="Address-wrapper">
+                            {' '}
+                            <div className="street">
+                                Confidential location
+                            </div>
+                            {' '}
+                            <div className="suburb">
+                                {suburb}
+                            </div>
+                        </div>
+                    </div>
+                    );
+        }
+
+        // Not confidential - describe street & have link to map
+
         var street = [
             this.describe("level", "Level"),
             this.describe("unit", "Unit"),
@@ -31,12 +71,6 @@ class Address extends React.Component {
             titleize(this.props.street_name),
             titleize(this.props.street_type),
             titleize(this.props.street_suffix),
-        ].join(" ").trim();
-
-        var suburb = [
-            titleize(this.props.suburb),
-            this.props.state,
-            titleize(this.props.postcode),
         ].join(" ").trim();
 
         var query = encodeURIComponent(`${street} ${suburb}`);

--- a/src/components/Address.js
+++ b/src/components/Address.js
@@ -47,6 +47,7 @@ class Address extends React.Component {
                         <ScreenReader>
                             <h4>Address</h4>
                         </ScreenReader>
+                        <icons.Map />
                         <div className="Address-wrapper">
                             {' '}
                             <div className="street">

--- a/src/components/ResultListItem.js
+++ b/src/components/ResultListItem.js
@@ -69,7 +69,10 @@ class ResultListItem extends React.Component {
                     className="opening_hours"
                     object={object.open}
                 />
-                <TransportTime object={object} />
+                <TransportTime
+                    object={object}
+                    linkDirections={false}
+                />
                 {this.props.nServiceProvisions > 0 ?
                     <div>
                         <ul className="related">{

--- a/src/components/ServicePane.js
+++ b/src/components/ServicePane.js
@@ -59,7 +59,10 @@ export default class ServicePane extends React.Component {
 
                     <CollapsedOpeningTimes object={object.open} />
                     <hr />
-                    <Address {...object.location} />
+                    <Address
+                        isConfidential={object.isConfidential}
+                        {...object.location}
+                    />
                     <hr />
                     {!object.isConfidential ?
                          <div>

--- a/src/components/ServicePane.js
+++ b/src/components/ServicePane.js
@@ -66,7 +66,10 @@ export default class ServicePane extends React.Component {
                     <hr />
                     {!object.isConfidential ?
                          <div>
-                             <TransportTime object={object} />
+                             <TransportTime
+                                 object={object}
+                                 linkDirections={true}
+                             />
                              <hr />
                         </div>
                      : ""}

--- a/src/components/ServicePane.js
+++ b/src/components/ServicePane.js
@@ -9,6 +9,7 @@ import Address from "../components/Address";
 import CollapsedOpeningTimes from "../components/CollapsedOpeningTimes";
 import ContactMethods from "../components/ContactMethods";
 import Eligibility from "../components/Eligibility";
+import TransportTime from "../components/TransportTime";
 import fixtures from "../../fixtures/services";
 import icons from "../icons";
 import iss from "../iss";
@@ -60,6 +61,12 @@ export default class ServicePane extends React.Component {
                     <hr />
                     <Address {...object.location} />
                     <hr />
+                    {!object.isConfidential ?
+                         <div>
+                             <TransportTime object={object} />
+                             <hr />
+                        </div>
+                     : ""}
                     <ContactMethods object={object} />
                 </main>
 

--- a/src/components/ServicePane.scss
+++ b/src/components/ServicePane.scss
@@ -50,6 +50,7 @@ $padding: 15px;
     }
 
     .OpeningTimes,
+    .TransportTime,
     .Address {
         svg {
             top: -6px !important;
@@ -58,9 +59,14 @@ $padding: 15px;
 
     .OpeningTimes,
     .Address,
+    .TransportTime,
     .CollapsedPhones {
         padding-top: 10px;
         padding-bottom: 10px;
+    }
+
+    .TransportTime .location {
+        display: none;
     }
 
     .List {

--- a/src/components/ServicePane.scss
+++ b/src/components/ServicePane.scss
@@ -50,7 +50,6 @@ $padding: 15px;
     }
 
     .OpeningTimes,
-    .TransportTime,
     .Address {
         svg {
             top: -6px !important;
@@ -65,8 +64,14 @@ $padding: 15px;
         padding-bottom: 10px;
     }
 
-    .TransportTime .location {
-        display: none;
+    .TransportTime {
+        .location {
+            display: none;
+        }
+
+        .ColoredIcon {
+            top: 6px;
+        }
     }
 
     .List {

--- a/src/components/TransportTime.js
+++ b/src/components/TransportTime.js
@@ -20,10 +20,16 @@ class TransportTime extends React.Component {
             object,
         } = this.props;
 
-        /* NB: We use CSS to suppress the location in detail view, and the
-         * get directions link in results listing view
+        /* NB: We use CSS to suppress TransportTime.location in detail view,
+         * and GetDirectionsLink in results listing view
          */
         if (!object.isConfidential) {
+
+            var point = encodeURIComponent(
+                `${this.props.object.location.point.lat},
+                ${this.props.object.location.point.lon}`);
+            var url = `https://maps.google.com/?saddr=Current+Location&daddr=${point}`;
+
             return (
                 <div className="TransportTime">
                     <icons.Walk className="ColoredIcon brand-text-dark" />
@@ -32,7 +38,7 @@ class TransportTime extends React.Component {
                         {titleize(this.props.object.location.suburb)}
                     </span>
                     <div className="GetDirectionsLink">
-                        <a href="#">Get directions</a>
+                        <a href={url}>Get directions</a>
                     </div>
                 </div>
             );

--- a/src/components/TransportTime.js
+++ b/src/components/TransportTime.js
@@ -20,6 +20,9 @@ class TransportTime extends React.Component {
             object,
         } = this.props;
 
+        /* NB: We use CSS to suppress the location in detail view, and the
+         * get directions link in results listing view
+         */
         if (!object.isConfidential) {
             return (
                 <div className="TransportTime">
@@ -28,6 +31,9 @@ class TransportTime extends React.Component {
                     <span className="location">
                         {titleize(this.props.object.location.suburb)}
                     </span>
+                    <div className="GetDirectionsLink">
+                        <a href="#">Get directions</a>
+                    </div>
                 </div>
             );
         } else {

--- a/src/components/TransportTime.js
+++ b/src/components/TransportTime.js
@@ -10,19 +10,25 @@ class TransportTime extends React.Component {
     // flow:disable not supported yet
     static propTypes = {
         object: React.PropTypes.object.isRequired,
+        linkDirections: React.PropTypes.Boolean,
     };
 
     // flow:disable not supported yet
-    static sampleProps = {default: {object: fixtures.ixa}};
+    static defaultProps = {
+        linkDirections: true,
+    };
+
+    // flow:disable not supported yet
+    static sampleProps = {default: {
+        object: fixtures.ixa,
+        linkDirections: false,
+    }};
 
     render(): ReactElement {
-        var {
-            object,
-        } = this.props;
 
-        /* NB: We use CSS to suppress TransportTime.location in detail view,
-         * and GetDirectionsLink in results listing view
-         */
+        var object = this.props.object;
+
+        /* NB We use CSS to suppress location in ServicePane */
         if (!object.isConfidential) {
 
             var point = encodeURIComponent(
@@ -37,9 +43,11 @@ class TransportTime extends React.Component {
                     <span className="location">
                         {titleize(this.props.object.location.suburb)}
                     </span>
-                    <div className="GetDirectionsLink">
-                        <a href={url}>Get directions</a>
-                    </div>
+                    {this.props.linkDirections ?
+                        <div className="GetDirectionsLink">
+                            <a href={url}>Get directions</a>
+                        </div>
+                    : ""}
                 </div>
             );
         } else {

--- a/src/components/TransportTime.js
+++ b/src/components/TransportTime.js
@@ -20,7 +20,7 @@ class TransportTime extends React.Component {
             object,
         } = this.props;
 
-        if (object.location.point) {
+        if (!object.isConfidential) {
             return (
                 <div className="TransportTime">
                     <icons.Walk className="ColoredIcon brand-text-dark" />

--- a/src/components/TransportTime.scss
+++ b/src/components/TransportTime.scss
@@ -14,7 +14,7 @@
 
     .time {
         color: $brand-text-dark;
-        font-weight: bold;
+        font-weight: 500;
     }
 
     .location {

--- a/src/components/TransportTime.scss
+++ b/src/components/TransportTime.scss
@@ -20,4 +20,11 @@
     .location {
         color: $brand-text-mid;
     }
+
+    .GetDirectionsLink {
+        position: absolute;
+
+        top: 10px;
+        right: 16px;
+    }
 }

--- a/src/iss.js
+++ b/src/iss.js
@@ -269,6 +269,13 @@ export class Service {
     get slug(): string {
         return slugify(`${this.id}-${this.site.name}`);
     }
+
+    /** If there is no point value, that means it's being suppressed */
+    /* flow:disable */
+    get isConfidential(): Boolean {
+        return !Boolean(this.location.point);
+    }
+
 }
 
 /**

--- a/src/pages/ResultsListPage.scss
+++ b/src/pages/ResultsListPage.scss
@@ -1,5 +1,9 @@
 .resultContainer {
     border-top: 10px solid $brand-bg-light;
+
+    .GetDirectionsLink {
+        display: none;
+    }
 }
 
 .resultContainer:first-child {

--- a/src/pages/ResultsListPage.scss
+++ b/src/pages/ResultsListPage.scss
@@ -67,7 +67,7 @@
         text-align: center;
     }
 
-    .TransportTime .ColoredIcon {
+    .TransportTime .WalkIcon {
         left: -27px;
     }
 

--- a/src/pages/ResultsListPage.scss
+++ b/src/pages/ResultsListPage.scss
@@ -66,11 +66,6 @@
         font-size: 14px !important;
         text-align: center;
     }
-
-    .TransportTime .WalkIcon {
-        left: -27px;
-    }
-
 }
 
 .homeLink {

--- a/src/pages/ResultsListPage.scss
+++ b/src/pages/ResultsListPage.scss
@@ -66,6 +66,11 @@
         font-size: 14px !important;
         text-align: center;
     }
+
+    .TransportTime .ColoredIcon {
+        left: -27px;
+    }
+
 }
 
 .homeLink {

--- a/test/features/10-functional/10-basic/40-service-details.feature
+++ b/test/features/10-functional/10-basic/40-service-details.feature
@@ -57,6 +57,16 @@ Feature: Service details page
         When I visit /service/866464
         Then I can get to google maps by clicking "33 Elizabeth Street Richmond VIC 3121"
 
+    Scenario: There is travel information for non-confidential services
+        When I visit /service/866464
+        Then I should see "? mins"
+        And I click on "Get directions"
+
+    Scenario: There is no travel information for confidential services
+        When I visit /service/537512
+        Then I should see "Confidential location"
+        And I should not see "Get directions"
+
     Scenario: The contact methods are available except fax and tty
        Given A service with:
         ----------------------------------------------

--- a/test/support/mock_iss/server.js
+++ b/test/support/mock_iss/server.js
@@ -292,6 +292,10 @@ app.get("/api/v3/service/866464/", (req, res) => {
     res.json(services.ixa);
 });
 
+app.get("/api/v3/service/537512/", (req, res) => {
+    res.json(services.domesticviolence);
+});
+
 app.get("/api/v3/service/13844/", (req, res) => {
     res.json(services.unhelpful);
 });


### PR DESCRIPTION
Closes https://trello.com/c/rxzpKN7H/209-no-directions-link-time-estimate-in-detail-view

Added 'isConfidential' flag to services, based on if they have a location.point value or not.

Confidential services have no transport/directions info included on their individual page. Also now the first line of their address will read "Confidential location".

Non-confidential services have the travel icon and time estimate same as is currently in the results listing view, but without the suburb (as the address is right above), and a "Get directions" link which is for Google Maps directions from "Current Location" to location.point.
