### PR TITLE
Move cross icon down a few pixels

### DIFF
--- a/src/pages/BasePersonalisationPage.scss
+++ b/src/pages/BasePersonalisationPage.scss
@@ -82,6 +82,10 @@
             height: 48px !important;
         }
 
+        .CrossIcon {
+            top: -6px !important;
+        }
+
         .LoadingIcon,
         .RadioUnselectedIcon,
         .RadioSelectedIcon {


### PR DESCRIPTION
Closes https://trello.com/c/BN0tgVX4/217-x-icon-is-not-well-positioned-after-personalisation-location-fail
