### PR TITLE
[Needs discussion] Ensure page transitions have completed before loading timeshift

### DIFF
--- a/test/steps/datetime.js
+++ b/test/steps/datetime.js
@@ -9,6 +9,8 @@ import Yadda from "yadda";
 import fs from "fs";
 import moment from "moment";
 
+import { documentReady } from "./browser";
+
 import unpromisify from "../support/yadda-promise";
 
 module.exports = (function() {
@@ -26,6 +28,7 @@ async function changeDay(day: string): Promise<void> {
     let script = fs.readFileSync(`${__dirname}/../support/timeshift.js`,
                                  {encoding: "utf-8"});
 
+    await this.driver.wait(documentReady(this.driver), 10000);
     await this.driver.executeScript(script);
     await this.driver.executeScript((time, offset) => {
         Date = window.TimeShift.Date;


### PR DESCRIPTION
We've had a bunch of spurious test failures around timeshift not loading correctly. 

I suspect the issue is that the page is transitioning across URLs and losing the script. 
This change seems to resolve it.
