### PR TITLE
Fix color/size of ResultLisItem heading

### DIFF
--- a/src/components/HeaderBar.scss
+++ b/src/components/HeaderBar.scss
@@ -1,5 +1,6 @@
 .HeaderBar {
-    /* FIXME check these */
+    @include clearfix;
+
     padding-right: 20px;
     padding-left: 20px;
 

--- a/src/components/ResultListItem.scss
+++ b/src/components/ResultListItem.scss
@@ -7,8 +7,8 @@
     .name {
         margin: 0;
         margin-bottom: 3px;
-        color: $brand-text-dark;
-        font-size: 18px;
+        color: $link-text-color;
+        font-size: 30px;
         font-weight: 500;
         line-height: 125%;
     }
@@ -16,6 +16,7 @@
     .site_name {
         margin-bottom: 16px;
         color: $brand-text-mid;
+        font-size: 23px;
     }
 
     .related {


### PR DESCRIPTION
Per discussion on https://trello.com/c/unNBPW7x/356-correct-colour-of-service-in-service-listing , having implemented this I think we'll need to adjust the size on the rest of the result list if we go ahead with this.
