### PR TITLE
Design updates 3

### DIFF
--- a/src/components/AppBar.scss
+++ b/src/components/AppBar.scss
@@ -35,6 +35,7 @@
 
         text-align: center;
 
+        text-overflow: ellipsis;
         white-space: nowrap;
         overflow: hidden;
     }

--- a/src/components/AppBar.scss
+++ b/src/components/AppBar.scss
@@ -24,8 +24,8 @@
     }
 
     .title {
-        flex: 4;
 
+        max-width: 80%;
         margin: auto;
         padding: 0;
 
@@ -41,6 +41,8 @@
     }
 
     .BackButton {
+        display: relative;
+        
         height: 40px;
         padding: 0;
 
@@ -48,7 +50,7 @@
 
         text-align: left;
         text-decoration: none;
-        white-space: nowrap;
+        overflow: hidden;
 
         &:focus {
             background-color: $brand-pane-alt-light-translucent;
@@ -69,21 +71,21 @@
         }
 
         span {
-            display: block;
-            position: absolute;
-            top: -1px;
-            left: -4px;
-
-            height: 40px;
-
-            &.back-label {
-                top: 0;
-                left: 28px;
-
-                font-size: 14px;
-                line-height: 38px;
-            }
+            margin-left: -6px;
+            float: left;
         }
+
+        .back-label {
+
+            margin-top: 1px;
+
+            font-size: 14px;
+            line-height: 38px;
+            
+            text-overflow: ellipsis;
+
+        }
+        
     }
 
 }

--- a/src/components/AppBar.scss
+++ b/src/components/AppBar.scss
@@ -19,12 +19,12 @@
     z-index: 2;
 
     & > .button-container {
-        flex: 2;
+        flex: 1;
         z-index: 2;
     }
 
     .title {
-        flex: 3;
+        flex: 4;
 
         margin: auto;
         padding: 0;

--- a/src/components/Contact.scss
+++ b/src/components/Contact.scss
@@ -24,20 +24,12 @@
 
         color: $brand-pane-alt-dark;
         font-size: 16px;
-        text-overflow: ellipsis;
-        overflow: hidden;
-
+        
         .Contact-text {
             padding-left: 30px;
-
-            .kind {
-                font-weight: 500;
-            }
-
-            .value {
-                display: inline-block;
-                word-break: break-all;
-            }
+            text-overflow: ellipsis;
+            white-space: nowrap;
+            overflow: hidden;
         }
 
         .Icon {

--- a/src/components/Contact.scss
+++ b/src/components/Contact.scss
@@ -24,7 +24,7 @@
 
         color: $brand-pane-alt-dark;
         font-size: 16px;
-        
+
         .Contact-text {
             padding-left: 30px;
             text-overflow: ellipsis;

--- a/src/components/Email.js
+++ b/src/components/Email.js
@@ -22,7 +22,6 @@ export default class Email extends React.Component {
                             {this.props.comment ? this.props.comment
                             : ""}
                         </span>
-                        {" "}
                         <span className="email value">{email}</span>
                     </div>
                 </a>

--- a/src/components/Email.js
+++ b/src/components/Email.js
@@ -19,7 +19,7 @@ export default class Email extends React.Component {
                     <icons.Email />
                     <div className="Contact-text">
                         <span className="kind">
-                            {this.props.comment ? this.props.comment
+                            {this.props.comment ? this.props.comment + " "
                             : ""}
                         </span>
                         <span className="email value">{email}</span>

--- a/src/components/Email.js
+++ b/src/components/Email.js
@@ -19,9 +19,9 @@ export default class Email extends React.Component {
                     <icons.Email />
                     <div className="Contact-text">
                         <span className="kind">
-                            {this.props.comment ? this.props.comment + " "
-                            : ""}
+                            {this.props.comment}
                         </span>
+                        {this.props.comment && " "}
                         <span className="email value">{email}</span>
                     </div>
                 </a>

--- a/src/components/ServicePane.js
+++ b/src/components/ServicePane.js
@@ -88,7 +88,7 @@ export default class ServicePane extends React.Component {
         }
 
         return (
-            <div className="padded">
+            <div className="Provisions">
                 <h3 className="serviceProvisions-header">
                     What you can get here
                 </h3>

--- a/src/components/ServicePane.js
+++ b/src/components/ServicePane.js
@@ -88,7 +88,7 @@ export default class ServicePane extends React.Component {
         }
 
         return (
-            <div className="Provisions">
+            <div className="serviceProvisions-container">
                 <h3 className="serviceProvisions-header">
                     What you can get here
                 </h3>
@@ -107,8 +107,8 @@ export default class ServicePane extends React.Component {
             return <span />;
         }
         return(
-            <div className="siblings">
-                <h3 className="padded">
+            <div className="siblings-container">
+                <h3 className="siblings-header">
                     Also at this location
                 </h3>
                 <div className="List">

--- a/src/components/ServicePane.scss
+++ b/src/components/ServicePane.scss
@@ -23,9 +23,10 @@ $padding: 15px;
 
     .padded {
         padding-right: $padding;
-        padding-left: $padding;
         padding-bottom: $padding;
+        padding-left: $padding;
     }
+
     .Eligibility,
     .Provisions {
         padding-right: $padding;

--- a/src/components/ServicePane.scss
+++ b/src/components/ServicePane.scss
@@ -21,19 +21,13 @@ $padding: 15px;
         }
     }
 
-    .padded {
-        padding-right: $padding;
-        padding-bottom: $padding;
-        padding-left: $padding;
-    }
-
+    // FIXME: Modifying child component styles
     .Eligibility,
-    .Provisions {
+    .serviceProvisions-container {
         padding-right: $padding;
         padding-left: $padding;
     }
 
-    
 
     main {
         margin: 0;
@@ -121,8 +115,14 @@ $padding: 15px;
         }
     }
 
-    .siblings {
+    .siblings-container {
         padding-top: 5px;
+
+        .siblings-header {
+            padding-right: $padding;
+            padding-bottom: $padding;
+            padding-left: $padding;
+        }
 
         .List > :first-child {
             border-top: 1px solid $list-item-hairline;

--- a/src/components/ServicePane.scss
+++ b/src/components/ServicePane.scss
@@ -21,10 +21,18 @@ $padding: 15px;
         }
     }
 
-    .padded,
-    .Eligibility {
-        padding: $padding;
+    .padded {
+        padding-right: $padding;
+        padding-left: $padding;
+        padding-bottom: $padding;
     }
+    .Eligibility,
+    .Provisions {
+        padding-right: $padding;
+        padding-left: $padding;
+    }
+
+    
 
     main {
         margin: 0;


### PR DESCRIPTION
Bunch of little changes:
- Fix truncation of page title
- Change how back-button labels work:
  - On most screens (pretty much everything except for the services detail page), there should be a back-button label present
  - When the title is too long, it will hide the back-button text, showing only the title.
- remove a no-breaking space from email display, which was looking weird
- clean up some padding on the service page
