### PR TITLE
Improve google maps link

### DIFF
--- a/src/components/GoogleMapsLink.js
+++ b/src/components/GoogleMapsLink.js
@@ -20,10 +20,7 @@ class GoogleMapsLink extends React.Component {
         const toAddr = this.props.to;
         const {travelTime} = toAddr;
         const mode = travelTime && travelTime.mode == "TRANSIT" ? "r" : "w";
-        const coords = storage.getJSON("coordinates");
-        const start = encodeURIComponent(
-            coords ? "Current Location" : `${storage.getItem("location")}`
-        );
+        const start = encodeURIComponent("Current Location");
         const query = encodeURIComponent([
             toAddr.flat_unit,
             toAddr.street_number,
@@ -39,8 +36,8 @@ class GoogleMapsLink extends React.Component {
         );
 
         return `https://maps.google.com/?dirflg=${mode
-        }&saddr=${start
-        }&daddr=${query}`;
+            }&saddr=${start
+            }&daddr=${query}`;
     }
 
     render(): ReactElement {

--- a/src/components/GoogleMapsLink.js
+++ b/src/components/GoogleMapsLink.js
@@ -3,7 +3,6 @@ import React from "react";
 import fixtures from "../../fixtures/services";
 import Location from "../iss/Location";
 import classnames from "classnames";
-import storage from "../storage";
 
 class GoogleMapsLink extends React.Component {
 

--- a/src/components/GoogleMapsLink.js
+++ b/src/components/GoogleMapsLink.js
@@ -3,12 +3,9 @@ import React from "react";
 import fixtures from "../../fixtures/services";
 import Location from "../iss/Location";
 import classnames from "classnames";
+import storage from "../storage";
 
 class GoogleMapsLink extends React.Component {
-
-    static defaultProps = {
-        from: "", // Empty string makes the maps app use your current location
-    };
 
     static sampleProps = {
         default: {
@@ -20,15 +17,30 @@ class GoogleMapsLink extends React.Component {
     };
 
     googleMapsUrl(): string {
-        let toAddr = this.props.to;
-
-        let start = encodeURIComponent(this.props.from);
-        let query = encodeURIComponent(
-            `${toAddr.streetAddressLine1()} ${toAddr.streetAddressLine2()}`
+        const toAddr = this.props.to;
+        const {travelTime} = toAddr;
+        const mode = travelTime && travelTime.mode == "TRANSIT" ? "r" : "w";
+        const coords = storage.getJSON("coordinates");
+        const start = encodeURIComponent(
+            coords ? "Current Location" : `${storage.getItem("location")}`
+        );
+        const query = encodeURIComponent([
+            toAddr.flat_unit,
+            toAddr.street_number,
+            toAddr.street_name,
+            toAddr.street_type,
+            toAddr.street_suffix,
+            toAddr.suburb,
+            toAddr.state,
+            toAddr.postcode,
+        ]
+            .join(" ")
+            .trim()
         );
 
-        // FIXME: Choose directionsmode based on expected travel time.
-        return `https://maps.google.com/?dirflg=w&saddr=${start}&daddr=${query}`;
+        return `https://maps.google.com/?dirflg=${mode
+        }&saddr=${start
+        }&daddr=${query}`;
     }
 
     render(): ReactElement {

--- a/src/components/ServicePane.js
+++ b/src/components/ServicePane.js
@@ -61,7 +61,6 @@ export default class ServicePane extends React.Component {
 
                     <GoogleMapsLink
                         className="plain-text"
-                        from="Current Location"
                         to={object.Location()}
                     >
                         <Address location={object.Location()} />


### PR DESCRIPTION
- Use transit directions if it’s quicker
- Only use “Current Location” if you’ve shared your coordinates with us
- Don’t include level / building names as they can confuse gmaps
