### PR TITLE
Normalise spacing between heading and content for service detail page

### DIFF
--- a/src/components/ServicePane.scss
+++ b/src/components/ServicePane.scss
@@ -119,8 +119,8 @@ $padding: 15px;
         padding-top: 5px;
 
         .siblings-header {
+            margin-bottom: 1em;
             padding-right: $padding;
-            padding-bottom: $padding;
             padding-left: $padding;
         }
 


### PR DESCRIPTION
Now it's 1em for everything.
