### PR TITLE
Count XHRs in progress and wait for them between test steps

### DIFF
--- a/src/iss.js
+++ b/src/iss.js
@@ -78,6 +78,12 @@ type XhrOptions = {
     beforeSend?: Function,
 };
 
+let xhrInProgress = 0;
+
+if (typeof window != "undefined") {
+    window.xhrCount = () => xhrInProgress;
+}
+
 /**
  * Wraps the http request code in a promise.
  *
@@ -86,15 +92,17 @@ type XhrOptions = {
  * @returns {Promise<Object>} a promise for the request.
  */
 function _request(obj: XhrOptions) {
-    return new Promise((resolve, reject) =>
+    return new Promise((resolve, reject) => {
+        xhrInProgress++;
         xhr(obj, (err, response, body) => {
+            xhrInProgress--;
             if (response.statusCode == 200) {
                 resolve(response);
             } else {
                 reject(response);
             }
         })
-    );
+    });
 }
 
 /**

--- a/test/steps/browser.js
+++ b/test/steps/browser.js
@@ -110,7 +110,10 @@ async function clickBack(): Promise<void> {
 module.exports.documentReady = function documentReady(
     driver: Webdriver.WebDriver
 ): Promise<boolean> {
-    return driver.executeScript(() => document.readyState == "complete");
+    return driver.executeScript(() =>
+        ((!window.xhrCount) || (window.xhrCount() == 0)) &&
+        (document.readyState == "complete")
+    );
 };
 
 async function urlIs(


### PR DESCRIPTION
This PR makes the documentation for `documentReady` accurate.
