### PR TITLE
Responsive tweaks

### DIFF
--- a/src/components/CollapsedOpeningTimes.scss
+++ b/src/components/CollapsedOpeningTimes.scss
@@ -4,7 +4,7 @@
     & > a {
         position: absolute;
         top: -30px;
-        right: 10px;
+        right: 0;
         font-size: 16px;
     }
 

--- a/src/components/CrisisLineItem.scss
+++ b/src/components/CrisisLineItem.scss
@@ -22,7 +22,7 @@
 
 .CrisisHeader {
     margin-right: 16px;
-    margin-bottom: 0;
+    margin-bottom: 5px;
     margin-left: 16px;
 
     font-size: 18px;

--- a/src/components/ListItem.scss
+++ b/src/components/ListItem.scss
@@ -9,6 +9,10 @@
         padding-bottom: 10px;
 
         font-size: 18px;
+
+        & > div > .leftIcon {
+            top: 15px;
+        }
     }
 
     &.hero {

--- a/src/components/ListItem.scss
+++ b/src/components/ListItem.scss
@@ -10,7 +10,7 @@
 
         font-size: 18px;
 
-        & > div > .leftIcon {
+        .leftIcon {
             top: 15px;
         }
     }

--- a/src/components/ResultList.scss
+++ b/src/components/ResultList.scss
@@ -22,7 +22,7 @@
     @media ($tablet) {
         .resultContainer-CrisisLineItem {
             display: inline-block;
-            width: 30%;
+            width: 48%;
         }
     }
 }

--- a/src/icons/icons.scss
+++ b/src/icons/icons.scss
@@ -26,8 +26,8 @@ svg.Icon {
     }
 
     &.big {
-        width: 48px;
-        height: 48px;
+        width: 42px;
+        height: 42px;
     }
 }
 

--- a/src/pages/BasePersonalisationPage.scss
+++ b/src/pages/BasePersonalisationPage.scss
@@ -128,7 +128,6 @@
         }
     }
 
-
     .padded {
         padding: 20px;
     }

--- a/src/pages/BasePersonalisationPage.scss
+++ b/src/pages/BasePersonalisationPage.scss
@@ -1,17 +1,26 @@
 .PersonalisationPage {
+
+    .link-text {
+        text-decoration: underline;
+    }
+
     .search {
         width: 100%;
+
+        padding-top: 20px;
+        padding-right: 20px;
+        padding-bottom: 20px;
+        padding-left: 20px;
+
         border-bottom: 1px solid $list-item-hairline;
+        background-color: $brand-bg-light;
+
+        box-sizing: border-box;
 
         input {
             display: block;
-            width: 90%;
-            margin-top: 20px;
-            margin-right: auto;
-            margin-bottom: 20px;
-            margin-left: auto;
-            padding: 5px;
-
+            width: 96%;
+            padding: 10px 2%;
             border: 1px solid $brand-bg-mid;
             border-radius: 3px;
             -webkit-appearance: none;
@@ -44,7 +53,8 @@
 
     .done-button,
     .okay-button,
-    .clear-button {
+    .clear-button,
+    .location-button {
         width: 100%;
 
         button {
@@ -117,6 +127,7 @@
             white-space: initial;
         }
     }
+
 
     .padded {
         padding: 20px;

--- a/src/pages/HomePage.scss
+++ b/src/pages/HomePage.scss
@@ -57,6 +57,13 @@
             g + g path {
                 fill: $brand-pane-alt-light;
             }
+            
+            @media ($tablet) {
+                display: inline-block;
+                margin-bottom: -16px;
+            }
+            
+            
         }
 
         .branding-copy {

--- a/src/pages/personalisation/Location.js
+++ b/src/pages/personalisation/Location.js
@@ -313,11 +313,13 @@ class Location extends React.Component {
                     require("has-geolocation") &&
                     this.state.geolocation == GeoLocationState.NOT_STARTED ?
                         <components.ButtonListItem
-                            className="taller"
+                            className="taller LocationButton"
                             onClick={this.onGeolocationClick.bind(this)}
-                            primaryText={<span className="link-color">
-                                Automatically detect your location
-                            </span>}
+                            primaryText={
+                                <span className="link-color link-text">
+                                    Get your current location
+                                </span>
+                            }
                             leftIcon={
                                 <icons.Location
                                     className="ColoredIcon icon-fg-color big"
@@ -357,15 +359,18 @@ class Location extends React.Component {
                     className="search"
                     onSubmit={this.nextStep.bind(this)}
                 >
-                    <input
-                        type="search"
-                        ref="search"
-                        onFocus={this.scrollToSearchControl.bind(this)}
-                        aria-label="Enter a suburb or postcode"
-                        placeholder="Enter a suburb or postcode"
-                        value={this.state.locationName}
-                        onChange={this.onSearchChange.bind(this)}
-                    />
+                    <div>
+                        <input
+                            type="search"
+                            ref="search"
+                            onFocus={this.scrollToSearchControl.bind(this)}
+                            aria-label="Search for a suburb or postcode"
+                            placeholder="Search for a suburb or postcode"
+                            value={this.state.locationName}
+                            onChange={this.onSearchChange.bind(this)}
+                        />
+                    </div>
+
                 </form>
                 {
                     /* any autocompletions we currently have */

--- a/test/features/10-functional/20-personalisation/10-geolocation.feature
+++ b/test/features/10-functional/20-personalisation/10-geolocation.feature
@@ -8,11 +8,11 @@ Feature: Geolocation
     Scenario: Use geolocation to find the user
         When I visit /category/housing/personalise/page/location
         Then I should see "Where are you?"
-        And I should see "Automatically detect your location"
+        And I should see "Get your current location"
         And the button "Done" should be disabled
 
         Given control of geolocation
-        When I click on "Automatically detect your location"
+        When I click on "Get your current location"
         Then I should see "Locating you..."
 
         Given I'm at 37.823S 144.998E
@@ -24,7 +24,7 @@ Feature: Geolocation
         When I visit /category/housing/personalise/page/location
 
         Given control of geolocation
-        When I click on "Automatically detect your location"
+        When I click on "Get your current location"
         Then I should see "Locating you..."
 
         When I deny access to geolocation

--- a/test/features/10-functional/20-personalisation/70-location-url.feature
+++ b/test/features/10-functional/20-personalisation/70-location-url.feature
@@ -13,7 +13,7 @@ Feature: Show location in url
         Then I should see "I found 3 services in Richmond, Victoria"
         When I click on "Change your answers"
         And I click on "Where are you?"
-        Then I should see "Automatically detect your location"
+        Then I should see "Get your current location"
         When I search for "carlt"
         And I click on "Carlton"
         And I click on "Done"

--- a/test/features/10-functional/20-personalisation/80-change-what-you-need.feature
+++ b/test/features/10-functional/20-personalisation/80-change-what-you-need.feature
@@ -35,7 +35,7 @@ Feature: Change your personalisation settings
     Scenario: Edit my location setting
         When I visit /category/housing/personalise/summary
         And I click on "Where are you?"
-        Then I should see "Automatically detect your location"
+        Then I should see "Get your current location"
 
         When I search for "carlt"
         And I click on "Carlton"

--- a/test/features/10-functional/20-personalisation/90-full-personalisation-flow.feature
+++ b/test/features/10-functional/20-personalisation/90-full-personalisation-flow.feature
@@ -18,7 +18,7 @@ Feature: Personalisation
         Then I should see "Where are you?"
 
         Given control of geolocation
-        When I click on "Automatically detect your location"
+        When I click on "Get your current location"
 
         Given I'm at 37.823S 144.998E
         Then I should see "Found your location"
@@ -53,7 +53,7 @@ Feature: Personalisation
         Then I should see "Where are you?"
 
         Given control of geolocation
-        When I click on "Automatically detect your location"
+        When I click on "Get your current location"
 
         Given I'm at 37.823S 144.998E
         Then I should see "Found your location"
@@ -82,7 +82,7 @@ Feature: Personalisation
         Then I should see "Where are you?"
 
         Given control of geolocation
-        When I click on "Automatically detect your location"
+        When I click on "Get your current location"
 
         Given I'm at 37.823S 144.998E
         Then I should see "Found your location"


### PR DESCRIPTION
Tweaks to responsive layout. 

Crisis lines are now two-across instead of three. Adjusted the positioning of the Open Times collapser button to put it in line with the directions button (which incidentally fixes the problem with a long "Open now until...")
