### PR TITLE
Revert "Removed minimum should match code"

### DIFF
--- a/src/constants/categories.js
+++ b/src/constants/categories.js
@@ -44,6 +44,7 @@ const categories:Array<Category> = [
                 "-(housing information) -hef " +
                 "-(holiday accommodation)",
             service_type: "housing",
+            minimum_should_match: "3<30% 7<50%",
         },
         personalisation: [
             personalisation.Location,


### PR DESCRIPTION
Reverts ask-izzy/ask-izzy#548

Testing shows that removing the `minimum_should_match` parameter _does not_ improve the crisis line behaviour. Since the quality of the search results is somewhat better _with_ this parameter in place, we'll leave it in.
