### PR TITLE
limit nodejs to 1.5GB of RAM rather than 4GB

### DIFF
--- a/script/prod-server
+++ b/script/prod-server
@@ -6,4 +6,4 @@ PATH=`npm bin`:$PATH
 export PORT=${PORT-8000}
 export NODE_ENV=production
 
-node index
+node --max_old_space_size 1536 index


### PR DESCRIPTION
limit nodejs single process to 1.5GB of RAM rather than 4GB.

As per https://github.com/nodejs/node-v0.x-archive/wiki/FAQ#what-is-the-memory-limit-on-a-node-process
