### PR TITLE
Revert "limit nodejs to 1.5GB of RAM rather than 4GB"

### DIFF
--- a/script/prod-server
+++ b/script/prod-server
@@ -6,4 +6,4 @@ PATH=`npm bin`:$PATH
 export PORT=${PORT-8000}
 export NODE_ENV=production
 
-node --max_old_space_size 1536 index
+node index


### PR DESCRIPTION
Reverts ask-izzy/ask-izzy#563

Appears to be preventing node from starting, with `node: bad option: --max_old_space_size`

See also, perhaps:
https://kibana.private.infoxchange.net.au/#/doc/logstash-*/logstash-2016.01.27/docker?id=AVKB2kpZvXyWs98dfW8V&_g=%28%29
