### PR TITLE
Disable npm's progress bar

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,8 +41,8 @@ RUN echo "Disabling non-essential packages" && \
 
 # Install the npm deps
 COPY package.json bower.json /app/
-RUN npm install && \
-    npm install --only=dev && \
+RUN npm install --no-progress && \
+    npm install --only=dev --no-progress && \
     npm cache clean && \
     $(npm bin)/bower install --allow-root
 


### PR DESCRIPTION
DO NOT MERGE THIS UNTIL TESTED AND PEER REVIEWED

Disabling npm's progress bar improves npm install times by a factor of 2x.
This is done by adding --no-progress to npm install lines according to their documentation.

https://twitter.com/gavinjoyce/status/691773956144119808?s=17
